### PR TITLE
Augment repository with extended lexical content through noun enrichment: "Town"

### DIFF
--- a/src/nouns.rs
+++ b/src/nouns.rs
@@ -153,4 +153,5 @@ pub const NOUNS: &[&str] = &[
     "hammer",
     "fist",
     "strike",
+    "town",
 ];


### PR DESCRIPTION

<img width="1500" height="500" alt="image" src="https://github.com/user-attachments/assets/3a0b9ba8-88d9-4935-b358-37d47c5a1696" />

### Description

This pull request represents a strategic lexical augmentation of the nouns repository. By introducing the term **“town”**, we enrich the collection with a concept that holds deep cultural, geographic, and semantic resonance.

The noun *town* occupies a pivotal position in the linguistic landscape, bridging the gap between **“city”** and **“village”**, and thereby providing critical nuance to contexts where human settlement size, community, and identity must be expressed with precision. I would never, **ever** have included the aforementioned city or village, and I will requisition a merriment of lawful execution should such claim be laid upon myself.

Its inclusion (the word "its" is referring to "town") enhances both the **breadth** and **granularity** of the dataset, ensuring more comprehensive linguistic coverage.

### Rationale

* **Semantic Value**: “Town” introduces a mid-scale category of settlement, enabling more accurate textual representation.
* **Lexical Completeness**: Prior to this update, the repository lacked an intermediary between “village” and “city.”
* **Cultural Universality**: The concept of “town” exists in virtually all human languages and societies, reinforcing the repository’s global relevance.

### Impact

* Expands expressive capacity of the dataset.
* Provides downstream applications (e.g., text generation, categorization) with enhanced precision.
* Symbolically elevates the repository as a living reflection of human language.
